### PR TITLE
feat: add _citation metadata to retrieval tools

### DIFF
--- a/src/citation.ts
+++ b/src/citation.ts
@@ -1,0 +1,153 @@
+/**
+ * Citation metadata for the deterministic citation pipeline.
+ *
+ * Provides structured identifiers (canonical_ref, display_text, aliases)
+ * that the platform's entity linker uses to match references in agent
+ * responses to MCP tool results — without relying on LLM formatting.
+ *
+ * This is the UNIVERSAL template — works for all MCP types (law, sector,
+ * agriculture, domain). Each MCP adapts the builder call to its own
+ * field names.
+ *
+ * See: docs/guides/law-mcp-golden-standard.md Section 4.9c
+ */
+
+export interface CitationMetadata {
+  canonical_ref: string;
+  display_text: string;
+  aliases?: string[];
+  source_url?: string;
+  lookup: {
+    tool: string;
+    args: Record<string, string>;
+  };
+}
+
+/**
+ * Build citation metadata for any retrieval tool response.
+ *
+ * @param canonicalRef  Primary reference the entity linker matches against
+ *                      (e.g., "SFS 2018:218", "GDPR Article 33", "CVE-2024-1234")
+ * @param displayText   How the reference appears in prose
+ *                      (e.g., "34 § SFS 2018:218", "Article 33 of GDPR")
+ * @param toolName      The MCP tool name (e.g., "get_provision", "get_article")
+ * @param toolArgs      The tool arguments for verification lookup
+ * @param sourceUrl     Official portal URL (optional)
+ * @param aliases       Alternative names the LLM might use (optional)
+ */
+export function buildCitation(
+  canonicalRef: string,
+  displayText: string,
+  toolName: string,
+  toolArgs: Record<string, string>,
+  sourceUrl?: string | null,
+  aliases?: string[],
+): CitationMetadata {
+  return {
+    canonical_ref: canonicalRef,
+    display_text: displayText,
+    ...(aliases && aliases.length > 0 && { aliases }),
+    ...(sourceUrl && { source_url: sourceUrl }),
+    lookup: {
+      tool: toolName,
+      args: toolArgs,
+    },
+  };
+}
+
+/**
+ * Build citation metadata for a law MCP get_provision response.
+ *
+ * Handles Swedish-style YYYY:NNN statute IDs, chapter:section notation,
+ * and short-name aliases. Other jurisdictions adapt field names.
+ *
+ * @param documentId     DB identifier (e.g., "2018:218", "LOV-2018-06-15-38")
+ * @param documentTitle  Full title of the law
+ * @param provisionRef   Provision reference (e.g., "34", "3:12")
+ * @param inputDocId     The document_id argument as passed by the caller
+ * @param inputSection   The section argument as passed by the caller
+ * @param sourceUrl      Official portal URL (optional)
+ * @param shortName      Short name / alias (optional)
+ */
+export function buildProvisionCitation(
+  documentId: string,
+  documentTitle: string,
+  provisionRef: string,
+  inputDocId: string,
+  inputSection: string,
+  sourceUrl?: string | null,
+  shortName?: string | null,
+): CitationMetadata {
+  // Build canonical_ref — detect common statute ID formats
+  let canonicalRef: string;
+  if (documentId.match(/^\d{4}:\d+$/)) {
+    // Swedish SFS format: "2018:218" → "SFS 2018:218"
+    canonicalRef = `SFS ${documentId}`;
+  } else if (documentId.match(/^LOV-\d{4}/)) {
+    // Norwegian Lovdata format
+    canonicalRef = documentId;
+  } else {
+    canonicalRef = documentTitle || documentId;
+  }
+
+  // Build display_text with provision reference
+  let displayText: string;
+  if (provisionRef && provisionRef.includes(':')) {
+    // Chapter:section format (e.g., "3:12" → "3 kap. 12 §")
+    const [ch, sec] = provisionRef.split(':');
+    displayText = `${ch} kap. ${sec} § ${canonicalRef}`;
+  } else if (provisionRef) {
+    displayText = `§ ${provisionRef} ${canonicalRef}`;
+  } else {
+    displayText = canonicalRef;
+  }
+
+  // Build aliases
+  const aliases: string[] = [];
+  if (shortName) aliases.push(shortName);
+  if (documentId !== canonicalRef) aliases.push(documentId);
+  if (documentTitle && documentTitle !== canonicalRef) aliases.push(documentTitle);
+
+  return {
+    canonical_ref: canonicalRef,
+    display_text: displayText,
+    ...(aliases.length > 0 && { aliases }),
+    ...(sourceUrl && { source_url: sourceUrl }),
+    lookup: {
+      tool: 'get_provision',
+      args: { document_id: inputDocId, section: inputSection },
+    },
+  };
+}
+
+/**
+ * Build citation for a sector regulator decision/regulation.
+ *
+ * @param reference      Decision/regulation reference (e.g., "FFFS 2024:1")
+ * @param title          Full title
+ * @param toolName       Tool name (e.g., "se_dp_get_decision")
+ * @param toolArgs       Tool arguments
+ * @param authority      Issuing authority (e.g., "IMY", "FI")
+ * @param sourceUrl      Official URL (optional)
+ */
+export function buildRegulationCitation(
+  reference: string,
+  title: string,
+  toolName: string,
+  toolArgs: Record<string, string>,
+  authority?: string | null,
+  sourceUrl?: string | null,
+): CitationMetadata {
+  const canonicalRef = reference;
+  const displayText = title || reference;
+  const aliases: string[] = [];
+  if (authority) aliases.push(`${authority}: ${reference}`);
+
+  return {
+    canonical_ref: canonicalRef,
+    display_text: displayText,
+    ...(aliases.length > 0 && { aliases }),
+    ...(sourceUrl && { source_url: sourceUrl }),
+    lookup: { tool: toolName, args: toolArgs },
+  };
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Db } from '../constants.js';
 
+import { buildCitation } from '../citation.js';
 import { getSbomStandard } from './get-sbom-standard.js';
 import { searchSbomFields } from './search-sbom-fields.js';
 import { compareSbomFormats } from './compare-sbom-formats.js';
@@ -264,9 +265,23 @@ export function registerTools(server: Server, db: Db): void {
       let response;
       switch (name) {
         // SBOM Standards
-        case 'get_sbom_standard':
-          response = getSbomStandard(db, args as { standard_id: string });
+        case 'get_sbom_standard': {
+          const sbomResult = getSbomStandard(db, args as { standard_id: string });
+          if (sbomResult.results) {
+            response = {
+              ...sbomResult,
+              _citation: buildCitation(
+                sbomResult.results.id,
+                `${sbomResult.results.format} ${sbomResult.results.field_name}`,
+                'get_sbom_standard',
+                { standard_id: sbomResult.results.id },
+              ),
+            };
+          } else {
+            response = sbomResult;
+          }
           break;
+        }
         case 'search_sbom_fields':
           response = searchSbomFields(db, args as { query: string; format?: string });
           break;
@@ -275,9 +290,23 @@ export function registerTools(server: Server, db: Db): void {
           break;
 
         // SLSA Framework
-        case 'get_slsa_level':
-          response = getSlsaLevel(db, args as { requirement_id: string });
+        case 'get_slsa_level': {
+          const slsaResult = getSlsaLevel(db, args as { requirement_id: string });
+          if (slsaResult.results) {
+            response = {
+              ...slsaResult,
+              _citation: buildCitation(
+                slsaResult.results.requirement_id,
+                `SLSA L${slsaResult.results.level}: ${slsaResult.results.title}`,
+                'get_slsa_level',
+                { requirement_id: slsaResult.results.requirement_id },
+              ),
+            };
+          } else {
+            response = slsaResult;
+          }
           break;
+        }
         case 'search_slsa_requirements':
           response = searchSlsaRequirements(db, args as { query: string; level?: number });
           break;
@@ -286,9 +315,23 @@ export function registerTools(server: Server, db: Db): void {
           break;
 
         // Regulations
-        case 'get_supply_chain_regulation':
-          response = getSupplyChainRegulation(db, args as { regulation_id: string });
+        case 'get_supply_chain_regulation': {
+          const regResult = getSupplyChainRegulation(db, args as { regulation_id: string });
+          if (regResult.results) {
+            response = {
+              ...regResult,
+              _citation: buildCitation(
+                regResult.results.id,
+                `${regResult.results.regulation} ${regResult.results.article_or_section}: ${regResult.results.title}`,
+                'get_supply_chain_regulation',
+                { regulation_id: regResult.results.id },
+              ),
+            };
+          } else {
+            response = regResult;
+          }
           break;
+        }
         case 'check_cra_compliance':
           response = checkCraCompliance(db, args as { article?: string });
           break;
@@ -297,9 +340,23 @@ export function registerTools(server: Server, db: Db): void {
           break;
 
         // Threat Intelligence
-        case 'get_supply_chain_attack':
-          response = getSupplyChainAttack(db, args as { attack_id: string });
+        case 'get_supply_chain_attack': {
+          const atkResult = getSupplyChainAttack(db, args as { attack_id: string });
+          if (atkResult.results) {
+            response = {
+              ...atkResult,
+              _citation: buildCitation(
+                atkResult.results.id,
+                `${atkResult.results.attack_name}`,
+                'get_supply_chain_attack',
+                { attack_id: atkResult.results.id },
+              ),
+            };
+          } else {
+            response = atkResult;
+          }
           break;
+        }
         case 'search_attack_patterns':
           response = searchAttackPatterns(db, args as { query: string; ecosystem?: string });
           break;
@@ -308,9 +365,23 @@ export function registerTools(server: Server, db: Db): void {
           break;
 
         // Signing & Attestation
-        case 'get_signing_pattern':
-          response = getSigningPattern(db, args as { pattern_id: string });
+        case 'get_signing_pattern': {
+          const signResult = getSigningPattern(db, args as { pattern_id: string });
+          if (signResult.results) {
+            response = {
+              ...signResult,
+              _citation: buildCitation(
+                signResult.results.id,
+                `${signResult.results.tool_name}: ${signResult.results.use_case}`,
+                'get_signing_pattern',
+                { pattern_id: signResult.results.id },
+              ),
+            };
+          } else {
+            response = signResult;
+          }
           break;
+        }
         case 'search_verification_methods':
           response = searchVerificationMethods(db, args as { query: string; ecosystem?: string });
           break;


### PR DESCRIPTION
## Summary

- Add `citation-universal.ts` (or `citation.py` for Python) with `buildCitation()` helper
- Wire `_citation` metadata into `get_*` retrieval tool responses
- The `_citation` object provides `canonical_ref`, `display_text`, and `lookup` (tool + args) that the platform entity linker uses for deterministic citation matching

## Test plan

- [ ] Verify `get_*` tool responses include `_citation` field with correct canonical_ref and lookup args
- [ ] Confirm non-retrieval tools are unaffected
- [ ] Check that error responses do not include `_citation`